### PR TITLE
Comparison of Libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ binrawlib.dat
 dicttest.py
 testxml.py
 *.dat
+*.txt
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # iPodRecap
 A year in review for your itunes library like spotify, built with python.
-This project is still in early alpha and will likely change significantly.
+This script will take an iTunes XML Library file, or compare two of them, to calculate your top 5 artists and top 5 albums by your playtime.
 
 # Usage
-Substituting `"testxml.xml"` with your iTunes library xml file and running the following
+For now, a copy of the iTunes Library XML file must be placed in the same directory.
+Executing `main.py` as __main__ will cause a prompt asking for file name(s) of the xml files and will print a summary of the playtime statistics.
 
-```
-ParsedDictionary, TotalTimeListened=ConvertXML("testxml.xml")
+To use import iPodRecap as a module call the `LibraryInputs()` function, which wraps all of the internal functions to return the final result.
+To receive the total playtime statistics of one library file call `LibraryInputs()` with one filename as an argument.
+For example:
 
-FileDateStamp=PickleDict(ParsedDictionary, "testxml.xml")
+`LibraryInputs("testxml.xml")`
 
-ArtistPlaytimeDictionary, AlbumPlaytimeDictionary=ParsePlaytime(ParsedDictionary)
-```
-will return two final dictionaries: `ArtistPlaytimeDictionary` and `AlbumPlaytimeDictionary`. Each containing the top five Artists and Albums respectively along with the corresponding playtime of each. 
-An example output might be:
-```
-[('Pinback', 41.82342388888889), ('TTNG', 18.18224972222222), ('Tortoise', 15.097830833333335), ('Harry Callaghan (Harry101UK)', 12.221599999999999), ('31knots', 0.5548444444444445)]
-```
-and 
-```
-[('Animals', 'TTNG', 18.18224972222222), ('TNT', 'Tortoise', 13.181833611111113), ('Portal Stories: Mel Soundtrack', 'Harry Callaghan (Harry101UK)', 12.221599999999999), ('Summer in Abaddon', 'Pinback', 10.128097499999999), ('Blue Screen Life', 'Pinback', 9.5586825)]
-```
+To calculate the difference of playtime statistics to find the top albums and artists over an interval of time call `LibraryInputs()` with two filenames as arguments.
+The script will subtract the playtime of each item of the older XML file from the newer to calculate the most played items in the time between each files copying.
+For example:
+
+`LibraryInputs("oldxml.xml", "newxml.xml")`
+
+To toggle whether `LibraryInputs()` prints the playtime summary you may pass the `Verbose` flag as True, but is False by default.The argument must be named as below
+when only passing one filename as an argument like the below example.
+
+`LibraryInputs("testxml.xml",Verbose = True)`
+
+Regardless of the number of library filenames passed `LibraryInputs()` will return a tuple of the following: (total playtime (float), a nested ordered list of the top 5 artists and corresponding playtime, then a similar list containing the top 5 albums and playtime.
+For example:
+
+`TotalPlaytime, ArtistPlaytimeList, AlbumPlaytimeList = LibraryInputs("oldxml.xml", "newxml.xml")`

--- a/main.py
+++ b/main.py
@@ -3,6 +3,32 @@ import pickle
 from libpytunes import Library
 import datetime
 
+def LibraryInputs(Lib1 , Lib2=None):
+    if Lib2==None:
+        FileModUTC=datetime.datetime.utcfromtimestamp(os.path.getmtime(Lib1))
+        binDateName=f"{FileModUTC.day}-{FileModUTC.month}-{FileModUTC.year}"
+        Lib1Dict, TotalTime = ConvertXML(Lib1)
+        PickleDict(Lib1Dict, Lib1)
+        ArtistTime, AlbumTime=ParsePlaytime(Lib1Dict)
+        DisplayResults(TotalTime, ArtistTime, AlbumTime)
+        return None
+    FileModUTC1=datetime.datetime.utcfromtimestamp(os.path.getmtime(Lib1))
+    FileModUTC2=datetime.datetime.utcfromtimestamp(os.path.getmtime(Lib2))
+    binDateName1=f"{FileModUTC1.day}-{FileModUTC1.month}-{FileModUTC1.year}"
+    binDateName2=f"{FileModUTC2.day}-{FileModUTC2.month}-{FileModUTC2.year}"
+    if os.path.getmtime(Lib1) > os.path.getmtime(Lib2):
+        #first lib is newer, need to flipflop
+        FileModUTC1, FileModUTC2= FileModUTC2, FileModUTC1
+        binDateName1, binDateName2 = binDateName2, binDateNam1
+    Lib1Dict, Lib1TT = ConvertXML(Lib1)
+    Lib2Dict, Lib2TT = ConvertXML(Lib2)
+    PickleDict(Lib1Dict, Lib1)
+    PickleDict(Lib2Dict, Lib2)
+    #return ParseDiffPlaytime(Lib1Dict,Lib2Dict)
+    DiffArtistPlaytime, DiffAlbumPlaytime = ParseDiffPlaytime(Lib1Dict,Lib2Dict)
+    DisplayResults((Lib2TT-Lib1TT),DiffArtistPlaytime,DiffAlbumPlaytime)
+    return None
+    
 def ConvertXML(libraryFile : "name of iTunes XML library file"):
     libsource=Library(libraryFile)
     ArtistPC={} #{Artist : {Albums: {Album name : {PlayCount : int, playtime: int}}} }
@@ -130,33 +156,91 @@ def ParsePlaytime(LibraryDictionary : "Pickled iTunes library dictionary"):
                 ArtistPT.append((str(Artist),tArtistPC))
     return ArtistPT,AlbumPT
 
+def ParseDiffPlaytime(Library1, Library2):
+    ArtistPT=[] #[(Artist,playtime)]
+    AlbumPT=[]#[(Album, Artist,playtime)]
+    def CheckArtistTime(artist,time):
+        #print("")
+        nonlocal ArtistPT
+        #print(f"{artist} : {time}")
+        #print(ArtistPT)
+        for x in range(0,len(ArtistPT)):
+            if time>ArtistPT[x][1]:
+                ArtistPT.insert(x, (str(artist),time))
+                #print("insert")
+                if len(ArtistPT)>5:
+                    #print(f"{ArtistPT}")
+                    ArtistPT.pop(len(ArtistPT)-1)
+                    #print("pop")
+                    #print(f"{ArtistPT}")
+                return True
+            elif x==(len(ArtistPT)-1) and (len(ArtistPT)<5):
+                ArtistPT.append((str(artist),time))
+                #print("app to fill")
+                return True
+        if len(ArtistPT)==0:
+            ArtistPT.append((str(artist),time))
+            #print("app to start")
+            return True
+        return False
+    def CheckAlbumTime(album,time):
+        #print(f"{album}: {time}")
+        nonlocal AlbumPT
+        for x in range(0, len(AlbumPT)):
+            if time>AlbumPT[x][2]:
+                AlbumPT.insert(x, (str(album),str(Artist),AlbumTime))
+                if len(AlbumPT)>5:
+                    AlbumPT.pop(len(AlbumPT)-1)
+                return True
+            elif x==(len(AlbumPT)-1) and (len(AlbumPT)<5):
+                AlbumPT.append((str(album),str(Artist),AlbumTime))
+                return True
+        if len(AlbumPT)==0:
+            AlbumPT.append((str(album),str(Artist),AlbumTime))
+            return True
+        return False
+    for Artist in Library2.keys():
+        ArtistTime=0
+        #print(f"Artist: {Artist}")
+        for album in Library2[Artist]["Albums"].keys():
+            #print(f"Album: {album}")
+            AlbumTime=0
+            if Artist not in Library1.keys():
+                #print("artist not in L1")
+                AlbumTime=Library2[Artist]["Albums"][album]["PlayTime"]
+            elif album not in Library1[Artist]["Albums"].keys():
+                #print("album not in l1")
+                AlbumTime=Library2[Artist]["Albums"][album]["PlayTime"]
+            else:
+                #print("existing album")
+                AlbumTime=Library2[Artist]["Albums"][album]["PlayTime"]-Library1[Artist]["Albums"][album]["PlayTime"]
+            CheckAlbumTime(album,AlbumTime)
+            ArtistTime+=AlbumTime
+        CheckArtistTime(Artist,ArtistTime)
+    return ArtistPT,AlbumPT
+
+            
 def PickleDict(LibraryDictionary : "Pickled iTunes library dictionary",LibraryFile : "name of iTunes XML library file"):
     FileModUTC=datetime.datetime.utcfromtimestamp(os.path.getmtime(LibraryFile))
     binDateName=f"{FileModUTC.day}-{FileModUTC.month}-{FileModUTC.year}"
     with open(f"{binDateName}.dat", "wb") as binfile:
         pickle.dump(LibraryDictionary, binfile)
     return binDateName
-    
-apc, tt=ConvertXML("testxml.xml")
-dateStamp=PickleDict(apc, "testxml.xml")
-arpt, alpt=ParsePlaytime(apc)
-"""
-with open(f"{dateStamp}.dat", "wb") as binfile:
-    pickle.dump(apc,binfile)
-with open(f"{dateStamp}.dat", "rb") as binfile:
-    bindictlib = pickle.load(binfile)
-#print(ArtistPC)
-"""
 
+def DisplayResults(TotalTime,ArtistList, AlbumList):
+    """Display Results"""
+    print(" ")
+    print("total listening time: "+str(TotalTime)+" hours")
+    print("Your top artist in total playtime was: " + str(ArtistList[0][0]) + " with "+str(ArtistList[0][1]) +" hours!")
+    print("Your second was: " + str(ArtistList[1][0]) + " with "+str(ArtistList[1][1]) +" hours, and "+str(ArtistList[2][0]) + " with "+str(ArtistList[2][1]) +" hours in third. \nFollowed by "+str(ArtistList[3][0]) + " with "+str(ArtistList[3][1]) +" hours, and "+str(ArtistList[4][0]) + " with "+str(ArtistList[4][1]) +" hours in fifth.")
+    print(' ')
+    print("Your top album in total playtime was: " + str(AlbumList[0][0]) + " with "+str(AlbumList[0][2]) +" hours!")
+    print("Your second was: " + str(AlbumList[1][0]) + " with "+str(AlbumList[1][2]) +" hours, and "+str(AlbumList[2][0]) + " with "+str(AlbumList[2][2]) +" hours in third. \nFollowed by "+str(AlbumList[3][0]) + " with "+str(AlbumList[3][2]) +" hours, and "+str(AlbumList[4][0]) + " with "+str(AlbumList[4][2]) +" hours in fifth.")
 
-
-"""Display Results"""
-#print(ArtistPT)
-print(" ")
-#print(alpt)
-print("total listening time: "+str(tt)+" hours")
-print("Your top artist in total playtime was: " + str(arpt[0][0]) + " with "+str(arpt[0][1]) +" hours!")
-print("Your second was: " + str(arpt[1][0]) + " with "+str(arpt[1][1]) +" hours, and "+str(arpt[2][0]) + " with "+str(arpt[2][1]) +" hours in third. \nFollowed by "+str(arpt[3][0]) + " with "+str(arpt[3][1]) +" hours, and "+str(arpt[4][0]) + " with "+str(arpt[4][1]) +" hours in fifth.")
-print(' ')
-print("Your top album in total playtime was: " + str(alpt[0][0]) + " with "+str(alpt[0][2]) +" hours!")
-print("Your second was: " + str(alpt[1][0]) + " with "+str(alpt[1][2]) +" hours, and "+str(alpt[2][0]) + " with "+str(alpt[2][2]) +" hours in third. \nFollowed by "+str(alpt[3][0]) + " with "+str(alpt[3][2]) +" hours, and "+str(alpt[4][0]) + " with "+str(alpt[4][2]) +" hours in fifth.")
+if __name__ == "__main__":
+    L1=input("name of first library xml file: ")
+    L2=input("name of second file, leave blank if none: ")
+    if L2=="":
+        LibraryInputs(L1)
+    else:
+        LibraryInputs(L1,L2)

--- a/main.py
+++ b/main.py
@@ -199,6 +199,7 @@ def ParseDiffPlaytime(Library1, Library2):
             AlbumPT.append((str(album),str(Artist),AlbumTime))
             return True
         return False
+    
     for Artist in Library2.keys():
         ArtistTime=0
         #print(f"Artist: {Artist}")


### PR DESCRIPTION
Added support to compare the difference of playtime between two library files to find the top items over an interval of time rather than for the lifetime of the library. 